### PR TITLE
chore: add missing .PHONY annotation to Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .DEFAULT_GOAL := run
 
+.PHONY: clean run
+
 clean:
 	docker compose down
 	docker rm -f $(docker ps -a -q)


### PR DESCRIPTION
## Summary
- Added `.PHONY` declaration for all Makefile targets (`clean`, `run`) to prevent conflicts with files of the same name

## Test plan
- [ ] Verify `make` targets still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)